### PR TITLE
CRM-4287: Change setting name to "searchPrimaryDetailsOnly"

### DIFF
--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -49,7 +49,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
     'includeOrderByClause' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'smartGroupCacheTimeout' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'defaultSearchProfileID' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'searchPrimaryEmailOnly' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
+    'searchPrimaryLocTypes' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
   );
 
   /**

--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -49,7 +49,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
     'includeOrderByClause' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'smartGroupCacheTimeout' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'defaultSearchProfileID' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'searchPrimaryLocTypes' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
+    'searchPrimaryDetailsOnly' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
   );
 
   /**

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2624,31 +2624,29 @@ class CRM_Contact_BAO_Query {
         }
         continue;
       }
+      $searchPrimary = '';
+      if (Civi::settings()->get('searchPrimaryLocTypes') || $apiEntity) {
+        $searchPrimary = " AND {$name}.is_primary = 1";
+      }
       switch ($name) {
         case 'civicrm_address':
-          if ($primaryLocation) {
-            $from .= " $side JOIN civicrm_address ON ( contact_a.id = civicrm_address.contact_id AND civicrm_address.is_primary = 1 )";
+          //CRM-14263 further handling of address joins further down...
+          if (!$primaryLocation) {
+            $searchPrimary = '';
           }
-          else {
-            //CRM-14263 further handling of address joins further down...
-            $from .= " $side JOIN civicrm_address ON ( contact_a.id = civicrm_address.contact_id ) ";
-          }
+          $from .= " $side JOIN civicrm_address ON ( contact_a.id = civicrm_address.contact_id {$searchPrimary} )";
           continue;
 
         case 'civicrm_phone':
-          $from .= " $side JOIN civicrm_phone ON (contact_a.id = civicrm_phone.contact_id AND civicrm_phone.is_primary = 1) ";
+          $from .= " $side JOIN civicrm_phone ON (contact_a.id = civicrm_phone.contact_id {$searchPrimary}) ";
           continue;
 
         case 'civicrm_email':
-          $searchPrimary = '';
-          if (Civi::settings()->get('searchPrimaryEmailOnly') || $apiEntity) {
-            $searchPrimary = " AND civicrm_email.is_primary = 1";
-          }
-          $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id) {$searchPrimary}";
+          $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id {$searchPrimary})";
           continue;
 
         case 'civicrm_im':
-          $from .= " $side JOIN civicrm_im ON (contact_a.id = civicrm_im.contact_id AND civicrm_im.is_primary = 1) ";
+          $from .= " $side JOIN civicrm_im ON (contact_a.id = civicrm_im.contact_id {$searchPrimary}) ";
           continue;
 
         case 'im_provider':
@@ -2658,7 +2656,7 @@ class CRM_Contact_BAO_Query {
           continue;
 
         case 'civicrm_openid':
-          $from .= " $side JOIN civicrm_openid ON ( civicrm_openid.contact_id = contact_a.id AND civicrm_openid.is_primary = 1 )";
+          $from .= " $side JOIN civicrm_openid ON ( civicrm_openid.contact_id = contact_a.id {$searchPrimary} )";
           continue;
 
         case 'civicrm_worldregion':

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2625,7 +2625,7 @@ class CRM_Contact_BAO_Query {
         continue;
       }
       $searchPrimary = '';
-      if (Civi::settings()->get('searchPrimaryLocTypes') || $apiEntity) {
+      if (Civi::settings()->get('searchPrimaryDetailsOnly') || $apiEntity) {
         $searchPrimary = " AND {$name}.is_primary = 1";
       }
       switch ($name) {

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -197,10 +197,10 @@ return array(
     'description' => 'If set, this will be the default profile used for contact search.',
     'help_text' => NULL,
   ),
-  'searchPrimaryLocTypes' => array(
+  'searchPrimaryDetailsOnly' => array(
     'group_name' => 'Search Preferences',
     'group' => 'Search Preferences',
-    'name' => 'searchPrimaryLocTypes',
+    'name' => 'searchPrimaryDetailsOnly',
     'type' => 'Boolean',
     'quick_form_type' => 'YesNo',
     'default' => 1,

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -205,10 +205,10 @@ return array(
     'quick_form_type' => 'YesNo',
     'default' => 1,
     'add' => '4.7',
-    'title' => 'Search Primary Location Types Only',
+    'title' => 'Search Primary Details Only',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.',
+    'description' => 'If enabled, only primary details (eg contact\'s primary email, phone, etc) will be included in Basic and Advanced Search results. Disabling this feature will allow users to match contacts using any email, phone etc detail.',
     'help_text' => NULL,
   ),
 );

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -197,18 +197,18 @@ return array(
     'description' => 'If set, this will be the default profile used for contact search.',
     'help_text' => NULL,
   ),
-  'searchPrimaryEmailOnly' => array(
+  'searchPrimaryLocTypes' => array(
     'group_name' => 'Search Preferences',
     'group' => 'Search Preferences',
-    'name' => 'searchPrimaryEmailOnly',
+    'name' => 'searchPrimaryLocTypes',
     'type' => 'Boolean',
     'quick_form_type' => 'YesNo',
     'default' => 1,
     'add' => '4.7',
-    'title' => 'Search Primary Email Only',
+    'title' => 'Search Primary Location Types Only',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'If enabled, only primary email address will be included when users search by Email. Secondary emails will only be displayed in Full Text search results. Disabling this feature will allow searching by any emails attached to the contact.',
+    'description' => 'If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.',
     'help_text' => NULL,
   ),
 );

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -37,10 +37,10 @@
             <td>{$form.includeEmailInName.html}<br />
                 <span class="description">{ts}If enabled, email addresses are automatically included when users search by Name. Disabling this feature will speed up search significantly for larger databases, but users will need to use the Email search fields (from Advanced Search, Search Builder, or Profiles) to find contacts by email address.{/ts}</span></td>
         </tr>
-        <tr class="crm-search-setting-form-block-searchPrimaryEmailOnly">
-            <td class="label">{$form.searchPrimaryEmailOnly.label}</td>
-            <td>{$form.searchPrimaryEmailOnly.html}<br />
-                <span class="description">{ts}If enabled, only primary email address will be included when users search by Email. Secondary emails will only be included in Full Text search results. Disabling this feature will allow searching by any emails attached to the contact.{/ts}</span>
+        <tr class="crm-search-setting-form-block-searchPrimaryLocTypes">
+            <td class="label">{$form.searchPrimaryLocTypes.label}</td>
+            <td>{$form.searchPrimaryLocTypes.html}<br />
+                <span class="description">{ts}If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.{/ts}</span>
             </td>
         </tr>
         <tr  class="crm-search-setting-form-block-includeNickNameInName">

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -37,9 +37,9 @@
             <td>{$form.includeEmailInName.html}<br />
                 <span class="description">{ts}If enabled, email addresses are automatically included when users search by Name. Disabling this feature will speed up search significantly for larger databases, but users will need to use the Email search fields (from Advanced Search, Search Builder, or Profiles) to find contacts by email address.{/ts}</span></td>
         </tr>
-        <tr class="crm-search-setting-form-block-searchPrimaryLocTypes">
-            <td class="label">{$form.searchPrimaryLocTypes.label}</td>
-            <td>{$form.searchPrimaryLocTypes.html}<br />
+        <tr class="crm-search-setting-form-block-searchPrimaryDetailsOnly">
+            <td class="label">{$form.searchPrimaryDetailsOnly.label}</td>
+            <td>{$form.searchPrimaryDetailsOnly.html}<br />
                 <span class="description">{ts}If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.{/ts}</span>
             </td>
         </tr>

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -40,7 +40,7 @@
         <tr class="crm-search-setting-form-block-searchPrimaryDetailsOnly">
             <td class="label">{$form.searchPrimaryDetailsOnly.label}</td>
             <td>{$form.searchPrimaryDetailsOnly.html}<br />
-                <span class="description">{ts}If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.{/ts}</span>
+                <span class="description">{ts}If enabled, only primary details (eg contact's primary email, phone, etc) will be included in Basic and Advanced Search results. Disabling this feature will allow users to match contacts using any email, phone etc detail.{/ts}</span>
             </td>
         </tr>
         <tr  class="crm-search-setting-form-block-includeNickNameInName">

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -152,7 +152,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test searchPrimaryLocTypes setting.
+   * Test searchPrimaryDetailsOnly setting.
    */
   public function testSearchPrimaryLocTypes() {
     $contactID = $this->individualCreate();
@@ -168,7 +168,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     $this->callAPISuccess('email', 'create', $params);
 
     foreach (array(0, 1) as $searchPrimary) {
-      Civi::settings()->set('searchPrimaryLocTypes', $searchPrimary);
+      Civi::settings()->set('searchPrimaryDetailsOnly', $searchPrimary);
 
       $params = array(
         0 => array(

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -152,9 +152,9 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test searchByPrimaryEmailOnly setting.
+   * Test searchPrimaryLocTypes setting.
    */
-  public function testSearchByPrimaryEmailOnly() {
+  public function testSearchPrimaryLocTypes() {
     $contactID = $this->individualCreate();
     $params = array(
       'contact_id' => $contactID,
@@ -168,7 +168,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     $this->callAPISuccess('email', 'create', $params);
 
     foreach (array(0, 1) as $searchPrimary) {
-      Civi::settings()->set('searchPrimaryEmailOnly', $searchPrimary);
+      Civi::settings()->set('searchPrimaryLocTypes', $searchPrimary);
 
       $params = array(
         0 => array(


### PR DESCRIPTION
Hey @jitendrapurohit!

Bit of a nitpick, but location types are not primaries ... eg a contact could have several emails of any location type but only one email (not location type) should be their "primary".

So am suggesting this change to the setting name for less confusing DX. What do you think?